### PR TITLE
Start basic HTTP server to serve app's static files

### DIFF
--- a/bin/lyrebird.dart
+++ b/bin/lyrebird.dart
@@ -1,0 +1,8 @@
+import 'server.dart';
+
+Future main() async {
+  final server = Server();
+  await server.run();
+
+  // TODO: Open browser.
+}

--- a/bin/server.dart
+++ b/bin/server.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+import 'dart:isolate';
+import 'package:alfred/alfred.dart';
+
+class Server {
+  final Alfred _app = Alfred();
+
+  Future run() async {
+    final wwwUri =
+        (await Isolate.resolvePackageUri(Uri.parse('package:lyrebird/')))
+            ?.resolve('../www');
+    if (wwwUri == null) throw 'Web assets not found.';
+    final directory = Directory.fromUri(wwwUri);
+
+    // TODO: Nicer (& colored) logging.
+    print('Serving from $directory.');
+
+    // TODO: Return the file whose path was specified via CLI.
+    // _app.get('/file', (req, res) => File(...));
+
+    // TODO: Implement PUT /file.
+
+    _app.get('/*', (req, res) => directory);
+
+    await _app.listen(32804);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.18.2 <3.0.0'
 
 dependencies: 
-  archive: ^3.3.5
+  alfred: ^1.0.0+1
   args: ^2.3.1
 
 dev_dependencies: 


### PR DESCRIPTION
This sets up a (very) basic server that hosts static files which are placed in the package root's `www` folder.