### PR TITLE
Add multi-file support to the server

### DIFF
--- a/bin/lyrebird.dart
+++ b/bin/lyrebird.dart
@@ -10,7 +10,7 @@ Future main(List<String> args) async {
   if (result.rest.isEmpty) throw 'Missing file argument';
 
   final server = Server(
-    file: File(result.arguments[0]),
+    directory: Directory(result.arguments[0]),
   );
   await server.run();
   print('Open ${server.url} in your browser to get started.');

--- a/bin/server.dart
+++ b/bin/server.dart
@@ -53,11 +53,17 @@ class Server {
 
     _app.get('/files', (req, res) async {
       // TODO: Include file metadata.
-      return await directory
-          .list()
-          .where((entity) => entity is File)
-          .map((file) => basename(file.path))
-          .toList();
+      return {
+        'directory': directory.absolute.uri
+            .normalizePath()
+            .toFilePath(windows: false)
+            .normalizePath,
+        'files': await directory
+            .list()
+            .where((entity) => entity is File)
+            .map((file) => basename(file.path))
+            .toList(),
+      };
     });
 
     _app.get('/file', (req, res) async {

--- a/bin/server.dart
+++ b/bin/server.dart
@@ -6,11 +6,13 @@ class Server {
   final Alfred _app = Alfred();
   String get url => 'http://${_app.server!.address.host}:${_app.server!.port}';
 
-  final File file;
+  final Directory directory;
 
   Server({
-    required this.file,
-  });
+    required this.directory,
+  }) {
+    if (!directory.existsSync()) throw 'The given directory does not exist.';
+  }
 
   static Future<Directory> _findDefaultBinaryDirectory() async {
     final wwwUri = await Isolate.resolvePackageUri(
@@ -18,6 +20,25 @@ class Server {
     ).then((uri) => uri?.resolve('../www'));
     if (wwwUri == null) throw 'Web assets not found.';
     return Directory.fromUri(wwwUri);
+  }
+
+  File _fileFromPath(String path) {
+    final file = File(directory.absolute.uri
+        .resolve(path)
+        .normalizePath()
+        .toFilePath(windows: false)
+        .normalizePath);
+
+    // Check if the file is in the given directory.
+    if (file.parent.absolute.path !=
+        directory.absolute.uri
+            .normalizePath()
+            .toFilePath(windows: false)
+            .normalizePath) {
+      throw 'You may not write to files outside the given directory.';
+    }
+
+    return file;
   }
 
   Future<void> run() async {
@@ -28,9 +49,30 @@ class Server {
 
     _app.all('*', cors(origin: '*'));
 
-    _app.get('/file', (req, res) => file);
+    _app.get('/file', (req, res) async {
+      final path = req.uri.queryParameters['path'];
+      if (path != null) {
+        final file = _fileFromPath(path);
+        if (!await file.exists()) throw 'File to does not exist.';
+        return file;
+      } else {
+        // TODO: Less sketchy validation.
+        throw 'No path given.';
+      }
+    });
+
+    // TODO: The current implementation allows probing for existing directories on the server by passing something like `../test/file.arb` as path and seeing if it resolves.
+    // TODO: Only allow arb files?
     _app.put('/file', (req, res) async {
-      await file.writeAsString((await req.body).toString(), flush: true);
+      final path = req.uri.queryParameters['path'];
+      if (path != null) {
+        final file = _fileFromPath(path);
+        if (!await file.exists()) throw 'File to update does not exist.';
+        await file.writeAsString((await req.body).toString(), flush: true);
+      } else {
+        // TODO: Less sketchy validation.
+        throw 'No path given.';
+      }
     });
 
     _app.get('/*', (req, res) async {


### PR DESCRIPTION
- The CLI now accepts a directory path instead of a file path as its argument.
- The `/file` endpoint now accepts a `path` query parameter for selecting a file from the given directory to read / update.
- A new `/files` endpoint returns the given directory path as well as all files within it.